### PR TITLE
Removed linebreaks / fixed raw css

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -14,8 +14,9 @@ Redmine::Plugin.register :redmine_gist do
   Redmine::WikiFormatting::Macros.register do
     desc "Embed raw html"
     macro :html do |obj, args|
-        # I also need to get rid of newlines here. How?
-        result = CGI::unescapeHTML(args.join(","))
+	      result = args.join(",")
+        result = result.gsub(/<\/?[^>]*>/, "")
+	      result = CGI::unescapeHTML(result)
         return result
     end	
   end
@@ -23,7 +24,11 @@ Redmine::Plugin.register :redmine_gist do
 	Redmine::WikiFormatting::Macros.register do
     desc "Embed raw css"
     macro :css do |obj, args|
-        result = "<style>"+args[0]+"</style>"
+        result = args[0]
+	      result = result.gsub(/\[/,'{')
+	      result = result.gsub(/\]/,'}')
+	      result = result.gsub(/<\/?[^>]*>/, "")
+	      result = "<style type=\"text/css\">"+result+"</style>"
         result
     end	
   end


### PR DESCRIPTION
I changed the code a little to remove all html tags inserted by redmine. (especially linebreaks)
Raw CSS is still not perfect. Redmine seems to skip macros with curly brackets in it.
As a workaround I convert [ and ] to { }. So you can use square brackets for css markup instead of the curly brackets. Not perfect, but working for me.

Tested with Redmine 1.3.1.stable.
